### PR TITLE
feat: ReadyScene, GameScene 구분, NetworkSceneLoading을 위한 LevelManager 추가

### DIFF
--- a/Client/.gitignore
+++ b/Client/.gitignore
@@ -81,3 +81,6 @@ _External_Assets/
 
 # Exception
 !/[Aa]ssets/Photon/Fusion/Assemblies/*.pdb
+
+# Fusion
+/[Aa]ssets/Photon/FusionDemos/

--- a/Client/Assets/Resources/Prefabs/Aliens/Stalker.prefab
+++ b/Client/Assets/Resources/Prefabs/Aliens/Stalker.prefab
@@ -1031,11 +1031,11 @@ GameObject:
   - component: {fileID: 2656646541101528400}
   - component: {fileID: 5652327032334742129}
   - component: {fileID: 4476358356948161216}
-  - component: {fileID: 7884986229739336368}
   - component: {fileID: 3683300922919915951}
   - component: {fileID: 788837692929703025}
   - component: {fileID: 8848567419615919483}
   - component: {fileID: 6976675480461094696}
+  - component: {fileID: 9205723220890699314}
   m_Layer: 0
   m_Name: Stalker
   m_TagString: Untagged
@@ -1100,9 +1100,9 @@ MonoBehaviour:
   NetworkedBehaviours:
   - {fileID: 5652327032334742129}
   - {fileID: 4476358356948161216}
-  - {fileID: 7884986229739336368}
   - {fileID: 8848567419615919483}
   - {fileID: 6976675480461094696}
+  - {fileID: 9205723220890699314}
 --- !u!114 &5652327032334742129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1140,18 +1140,6 @@ MonoBehaviour:
   _WalkSpeed: 0
   _RunSpeed: 0
   _Damage: 0
---- !u!114 &7884986229739336368
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8694943018831287373}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6890c92ffee41c7b35303c032f1d7fd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!136 &3683300922919915951
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -1255,6 +1243,18 @@ MonoBehaviour:
     StepRequireGroundTarget: 0
     SnapDistance: 0.25
     SnapSpeed: 4
+--- !u!114 &9205723220890699314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8694943018831287373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94ff61e00a954d2ca211bbcd85136341, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8694943018831287375
 GameObject:
   m_ObjectHideFlags: 0

--- a/Client/Assets/Scenes/GameScene.unity
+++ b/Client/Assets/Scenes/GameScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 1.121193, g: 0.86418355, b: 0.9683758, a: 1}
+  m_IndirectSpecularColor: {r: 1.121193, g: 0.8641804, b: 0.9683758, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -899,10 +899,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 45183433}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 45183432}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -964,6 +968,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &45183433 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 45183430}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &50717013
@@ -1350,10 +1365,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 96816206}
+    - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 96816205}
     - target: {fileID: 8372542608119709909, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
@@ -1379,6 +1398,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &96816206 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1254759295562782899, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+  m_PrefabInstance: {fileID: 96816203}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &101539776
@@ -1747,10 +1777,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 162268699}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 162268698}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -1812,6 +1846,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &162268699 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 162268696}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &174728257
@@ -2371,10 +2416,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 356963429}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 356963428}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -2436,6 +2485,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &356963429 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 356963426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &364990937
@@ -2720,10 +2780,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 380661540}
+    - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 380661539}
     - target: {fileID: 8372542608119709909, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
@@ -2749,6 +2813,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &380661540 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1254759295562782899, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+  m_PrefabInstance: {fileID: 380661537}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &395915193
@@ -3063,7 +3138,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
@@ -3085,13 +3160,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &477145453 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1053169980762872978, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7032645045039268006, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
   m_PrefabInstance: {fileID: 477145451}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &484273059
@@ -8585,7 +8660,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
@@ -8607,13 +8682,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &1504960049 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1053169980762872978, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7032645045039268006, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
   m_PrefabInstance: {fileID: 1504960047}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1528917505
@@ -11069,67 +11144,6 @@ MonoBehaviour:
   Components:
   - {fileID: 2123864769}
   _guid: 4f16456c-565b-4102-
---- !u!1001 &2146260096
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -218.45801
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 427.77283
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -460.50403
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1871540468047246183, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: SortKey
-      value: 25487127
-      objectReference: {fileID: 0}
-    - target: {fileID: 1927622514374961410, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_Name
-      value: PlayerSystem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -11141,4 +11155,3 @@ SceneRoots:
   - {fileID: 1158283467}
   - {fileID: 1380135492}
   - {fileID: 212435520}
-  - {fileID: 2146260096}

--- a/Client/Assets/Scenes/ReadyScene.unity
+++ b/Client/Assets/Scenes/ReadyScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 1.121193, g: 0.86418355, b: 0.9683758, a: 1}
+  m_IndirectSpecularColor: {r: 1.121193, g: 0.8641804, b: 0.9683758, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -899,10 +899,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 45183433}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 45183432}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -964,6 +968,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &45183433 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 45183430}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &50717013
@@ -1350,10 +1365,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 96816206}
+    - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 96816205}
     - target: {fileID: 8372542608119709909, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
@@ -1379,6 +1398,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &96816206 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1254759295562782899, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+  m_PrefabInstance: {fileID: 96816203}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &101539776
@@ -1747,10 +1777,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 162268699}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 162268698}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -1812,6 +1846,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &162268699 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 162268696}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &174728257
@@ -2371,10 +2416,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 356963429}
+    - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 356963428}
     - target: {fileID: 8871043851894611041, guid: 02871413d2295434fbaac77082fec791, type: 3}
@@ -2436,6 +2485,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &356963429 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 62817416060429354, guid: 02871413d2295434fbaac77082fec791, type: 3}
+  m_PrefabInstance: {fileID: 356963426}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &364990937
@@ -2720,10 +2780,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
+      value: 
+      objectReference: {fileID: 380661540}
+    - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+      propertyPath: NetworkedBehaviours.Array.data[1]
       value: 
       objectReference: {fileID: 380661539}
     - target: {fileID: 8372542608119709909, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
@@ -2749,6 +2813,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &380661540 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1254759295562782899, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
+  m_PrefabInstance: {fileID: 380661537}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &395915193
@@ -3063,7 +3138,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
@@ -3085,13 +3160,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &477145453 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1053169980762872978, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7032645045039268006, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
   m_PrefabInstance: {fileID: 477145451}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &484273059
@@ -7291,67 +7366,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1247980437}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1253770442
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -218.45801
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 427.77283
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -460.50403
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1871540468047246183, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: SortKey
-      value: 2258040028
-      objectReference: {fileID: 0}
-    - target: {fileID: 1927622514374961410, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_Name
-      value: PlayerSystem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
 --- !u!1001 &1270990151
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8646,7 +8660,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.data[0]
@@ -8668,13 +8682,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &1504960049 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1053169980762872978, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7032645045039268006, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
   m_PrefabInstance: {fileID: 1504960047}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 506319458, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1528917505
@@ -11141,4 +11155,3 @@ SceneRoots:
   - {fileID: 1158283467}
   - {fileID: 1380135492}
   - {fileID: 212435520}
-  - {fileID: 1253770442}

--- a/Client/Assets/Scenes/ReadyScene.unity
+++ b/Client/Assets/Scenes/ReadyScene.unity
@@ -132,7 +132,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 14874633}
-  - component: {fileID: 14874632}
+  - component: {fileID: 14874634}
   m_Layer: 0
   m_Name: '@Scene'
   m_TagString: Untagged
@@ -140,18 +140,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &14874632
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14874631}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3a3b3d0819bfcf74982c651c13256b09, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &14874633
 Transform:
   m_ObjectHideFlags: 0
@@ -167,6 +155,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &14874634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14874631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a09eed277cd5a5b41a1c122436af500f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &21547074
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -217,7 +217,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2796764676794190687, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: SortKey
-      value: 744695016
+      value: 2324556618
       objectReference: {fileID: 0}
     - target: {fileID: 8627056606023169588, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: m_Name
@@ -895,7 +895,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: SortKey
-      value: 2625280388
+      value: 4205141990
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -1346,7 +1346,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: SortKey
-      value: 1549416613
+      value: 3129278215
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -1743,7 +1743,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: SortKey
-      value: 3708665651
+      value: 993559957
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -2367,7 +2367,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: SortKey
-      value: 3355652265
+      value: 640546571
       objectReference: {fileID: 0}
     - target: {fileID: 8649354896696592089, guid: 02871413d2295434fbaac77082fec791, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -2492,7 +2492,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8460561394741268781, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
       propertyPath: SortKey
-      value: 283194203
+      value: 1863055805
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2716,7 +2716,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: SortKey
-      value: 1778172024
+      value: 3358033626
       objectReference: {fileID: 0}
     - target: {fileID: 7619613960391375424, guid: 7d86f0c0588612c4ca00515444f26dde, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -3059,7 +3059,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: SortKey
-      value: 2641898350
+      value: 4221759952
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -3071,7 +3071,7 @@ PrefabInstance:
       objectReference: {fileID: 477145453}
     - target: {fileID: 7026330786116388922, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: SortKey
-      value: 2333446884
+      value: 3913308486
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4157,7 +4157,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4885748426217312381, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
       propertyPath: SortKey
-      value: 58471836
+      value: 1638333438
       objectReference: {fileID: 0}
     - target: {fileID: 7082251819700908371, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
       propertyPath: m_LocalPosition.x
@@ -5177,7 +5177,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2745531498441078155, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
       propertyPath: SortKey
-      value: 345062350
+      value: 1924923952
       objectReference: {fileID: 0}
     - target: {fileID: 4094177302106422935, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
       propertyPath: m_Name
@@ -7291,6 +7291,67 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1247980437}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1253770442
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -218.45801
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 427.77283
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -460.50403
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1871540468047246183, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: SortKey
+      value: 2258040028
+      objectReference: {fileID: 0}
+    - target: {fileID: 1927622514374961410, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
+      propertyPath: m_Name
+      value: PlayerSystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
 --- !u!1001 &1270990151
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8020,7 +8081,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2106809236708486862, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
       propertyPath: SortKey
-      value: 772901617
+      value: 2352763219
       objectReference: {fileID: 0}
     - target: {fileID: 2278381717658941750, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
       propertyPath: m_Name
@@ -8581,7 +8642,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: SortKey
-      value: 2920036089
+      value: 204930395
       objectReference: {fileID: 0}
     - target: {fileID: 4079248258360484710, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: NetworkedBehaviours.Array.size
@@ -8593,7 +8654,7 @@ PrefabInstance:
       objectReference: {fileID: 1504960049}
     - target: {fileID: 7026330786116388922, guid: 0754c19ac0264d045a4a25cc96195ff2, type: 3}
       propertyPath: SortKey
-      value: 2611584623
+      value: 4191446225
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -10204,7 +10265,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 76067771806322262, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
       propertyPath: SortKey
-      value: 1799045824
+      value: 3378907426
       objectReference: {fileID: 0}
     - target: {fileID: 1845699543241681820, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11028,7 +11089,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3613581927921907817, guid: e26d3f8bca6fbf943b5cd072cc024214, type: 3}
       propertyPath: SortKey
-      value: 1387997324
+      value: 2967858926
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -11069,67 +11130,6 @@ MonoBehaviour:
   Components:
   - {fileID: 2123864769}
   _guid: 4f16456c-565b-4102-
---- !u!1001 &2146260096
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -218.45801
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 427.77283
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -460.50403
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1338067223963657617, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1871540468047246183, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: SortKey
-      value: 25487127
-      objectReference: {fileID: 0}
-    - target: {fileID: 1927622514374961410, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
-      propertyPath: m_Name
-      value: PlayerSystem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 67967f1a89c905847abdf60c0c51c7aa, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -11141,4 +11141,4 @@ SceneRoots:
   - {fileID: 1158283467}
   - {fileID: 1380135492}
   - {fileID: 212435520}
-  - {fileID: 2146260096}
+  - {fileID: 1253770442}

--- a/Client/Assets/Scenes/ReadyScene.unity.meta
+++ b/Client/Assets/Scenes/ReadyScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e56f48c222531e446828bb61255cce9b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Contents/AnimController/BaseAnimController.cs
+++ b/Client/Assets/Scripts/Contents/AnimController/BaseAnimController.cs
@@ -18,7 +18,7 @@ public abstract class BaseAnimController : NetworkBehaviour
     protected virtual void Init()
     {
         NetworkAnim = gameObject.GetComponent<NetworkMecanimAnimator>();
-        Creature = gameObject.GetComponent<Crew>();
+        Creature = gameObject.GetComponent<Creature>();
 
         SetFloat("moveSpeed", 0);
     }

--- a/Client/Assets/Scripts/Managers/Contents/GameManagerEX.cs
+++ b/Client/Assets/Scripts/Managers/Contents/GameManagerEX.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 using Fusion;
 using System.Data.SqlTypes;
 using System.Linq;
+using UnityEngine.SceneManagement;
+using System.Threading.Tasks;
 
 [Serializable]
 public class SaveData
@@ -21,6 +23,13 @@ public class GameManagerEX
     public string SAVEDATA_PATH;
 
     public Player Player { get; set; }
+    public List<Player> AllPlayers
+    {
+        get
+        {
+            return Managers.NetworkMng.Runner.GetAllBehaviours<Player>();
+        }
+    } 
     public void Init()
     {
         SAVEDATA_PATH = Path.Combine(Application.persistentDataPath, "/SaveData.json");
@@ -47,16 +56,16 @@ public class GameManagerEX
         StartGame();
     }
 
-    public void StartGame()
+    public async void StartGame()
     {
         Debug.Log("Game Setting Start");
-        Managers.UIMng.ClosePopupUI();
+        var popup = Managers.UIMng.FindPopup<UI_StartGame>();
+        popup.ClosePopupUI();
 
         if (Managers.NetworkMng.IsMaster)
         {
-            var players = Managers.NetworkMng.Runner.ActivePlayers.ToList();
-            int random = UnityEngine.Random.Range(0, players.Count);
-            Player.RPC_ChangePlayerToAlien(Managers.NetworkMng.Runner, players[random], Define.ALIEN_STALKER_ID);
+            // await Managers.NetworkMng.Runner.UnloadScene(SceneRef.FromIndex(SceneManager.GetActiveScene().buildIndex));
+            await Managers.NetworkMng.Runner.LoadScene(SceneRef.FromIndex(SceneUtility.GetBuildIndexByScenePath("Assets/Scenes/GameScene.unity")));
         }
     }
     #endregion

--- a/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
+++ b/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
@@ -54,7 +54,7 @@ public class ObjectManager
 
     public void Despawn(NetworkObject no)
     {
-        Creature creature = no.GetComponent<Crew>();
+        Creature creature = no.GetComponent<Creature>();
         if (creature.CreatureType == Define.CreatureType.Crew)
             Crews.Remove(no.Id);
         else if (creature.CreatureType == Define.CreatureType.Alien)

--- a/Client/Assets/Scripts/Managers/Core/SceneManagerEx.cs
+++ b/Client/Assets/Scripts/Managers/Core/SceneManagerEx.cs
@@ -30,7 +30,7 @@ public class SceneManagerEx
     /// </summary>
     /// <param name="type"></param>
     /// <returns></returns>
-    string GetSceneName(Define.SceneType type)
+    public string GetSceneName(Define.SceneType type)
     {
         string name = System.Enum.GetName(typeof(Define.SceneType), type);
         return name;

--- a/Client/Assets/Scripts/Networks/LevelManager.cs
+++ b/Client/Assets/Scripts/Networks/LevelManager.cs
@@ -1,0 +1,48 @@
+using DG.Tweening.Core.Easing;
+using Fusion;
+using System;
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.Serialization;
+using Random = UnityEngine.Random;
+
+public class LevelManager : NetworkSceneManagerDefault
+{
+    private SceneRef _loadedScene = SceneRef.None;
+
+    public override void Shutdown()
+    {
+        if (_loadedScene.IsValid)
+        {
+            SceneManager.UnloadSceneAsync(_loadedScene.AsIndex);
+            _loadedScene = SceneRef.None;
+        }
+        base.Shutdown();
+    }
+
+    protected override IEnumerator UnloadSceneCoroutine(SceneRef prevScene)
+    {
+        yield return base.UnloadSceneCoroutine(prevScene);
+    }
+
+    protected override IEnumerator OnSceneLoaded(SceneRef newScene, Scene loadedScene, NetworkLoadSceneParameters sceneFlags)
+    {
+        yield return base.OnSceneLoaded(newScene, loadedScene, sceneFlags);
+
+        var session = loadedScene.FindComponent<PlayerSystem>();
+        Managers.NetworkMng.PlayerSystem = session;
+
+        if (loadedScene.name == Managers.SceneMng.GetSceneName(Define.SceneType.GameScene))
+        {
+            session.PlayerJoined();
+
+            yield return new WaitForSeconds(3);
+
+            var players = Managers.NetworkMng.Runner.ActivePlayers.ToList();
+            int random = Random.Range(0, players.Count);
+            Player.RPC_ChangePlayerToAlien(Managers.NetworkMng.Runner, players[random], Define.ALIEN_STALKER_ID);
+        }
+    }
+}

--- a/Client/Assets/Scripts/Networks/LevelManager.cs.meta
+++ b/Client/Assets/Scripts/Networks/LevelManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92580b85361267b45b0c9dcf91b796f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Scenes/ReadyScene.cs
+++ b/Client/Assets/Scripts/Scenes/ReadyScene.cs
@@ -1,17 +1,18 @@
 using UnityEngine;
 
-public class GameScene : BaseScene
+public class ReadyScene : BaseScene
 {
     // 씬이 초기에 생성될 때 수행될 목록
     protected override void Init()
     {
         base.Init();
-        SceneType = Define.SceneType.GameScene;
+
+        SceneType = Define.SceneType.ReadyScene;
 
         Managers.MapMng.Init();
 
-        //Managers.UIMng.ShowPopupUI<UI_CrewStat>();
-        Managers.UIMng.ShowSceneUI<UI_Ingame>();
+        Managers.UIMng.ShowPopupUI<UI_StartGame>();
+        StartCoroutine(Managers.GameMng.TryStartGame());
     }
 
     // 씬이 바뀔 때 정리해야 하는 목록

--- a/Client/Assets/Scripts/Scenes/ReadyScene.cs.meta
+++ b/Client/Assets/Scripts/Scenes/ReadyScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a09eed277cd5a5b41a1c122436af500f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/UI/Scene/UI_StartGame.cs
+++ b/Client/Assets/Scripts/UI/Scene/UI_StartGame.cs
@@ -86,4 +86,9 @@ public class UI_StartGame : UI_Popup
     {
         GetText((int)Texts.ReadyCount).text = $"{count} / {Define.PLAYER_COUNT}";
     }
+
+    public override void Clear()
+    {
+        Managers.NetworkMng.PlayerSystem.OnReadyCountUpdated -= () => SetInfo(Managers.NetworkMng.PlayerSystem.ReadyCount);
+    }
 }

--- a/Client/Assets/Scripts/UI/UI_Popup.cs
+++ b/Client/Assets/Scripts/UI/UI_Popup.cs
@@ -23,6 +23,12 @@ public class UI_Popup : UI_Base
     /// </summary>
     public virtual void ClosePopupUI()
     {
+        Clear();
         Managers.UIMng.ClosePopupUI(this);
+    }
+
+    public virtual void Clear()
+    {
+
     }
 }

--- a/Client/Assets/Scripts/UI/WorldSpace/UI_NameTag.cs
+++ b/Client/Assets/Scripts/UI/WorldSpace/UI_NameTag.cs
@@ -47,6 +47,9 @@ public class UI_NameTag : UI_Base
 
     private void Update()
     {
+        if (Camera.main == null)
+            return;
+
         Nickname.transform.LookAt(Camera.main.transform);
     }
 }

--- a/Client/Assets/Scripts/Utils/Define.cs
+++ b/Client/Assets/Scripts/Utils/Define.cs
@@ -22,6 +22,7 @@ public static class Define
     public enum SceneType
     {
         UnknownScene,
+        ReadyScene,
         LobbyScene,
         GameScene,
         Map_JSJ,
@@ -135,7 +136,7 @@ public static class Define
 
     #region Value
 
-    public const int PLAYER_COUNT = 3;
+    public const int PLAYER_COUNT = 2;
     public const int MAX_ITEM_NUM = 4;
     public const float PLAYER_SPAWN_POSITION_X = 20f;
     public const float PLAYER_SPAWN_POSITION_Y = 0.3f;

--- a/Client/ProjectSettings/EditorBuildSettings.asset
+++ b/Client/ProjectSettings/EditorBuildSettings.asset
@@ -9,6 +9,9 @@ EditorBuildSettings:
     path: Assets/Scenes/LobbyScene.unity
     guid: 313716ee8bf524042a1788a7d3eb73ad
   - enabled: 1
+    path: Assets/Scenes/ReadyScene.unity
+    guid: e56f48c222531e446828bb61255cce9b
+  - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: 9fc0d4010bbf28b4594072e72b8655ab
   - enabled: 1
@@ -22,5 +25,5 @@ EditorBuildSettings:
     guid: 5125334a676103e43912c7c25b1c34ea
   - enabled: 0
     path: Assets/Scenes/TestScene/Map_JSJ.unity
-    guid: 1ebe0855672675e418fb8b0b4e7a4a38
+    guid: aef853be324e76d4484ffcd099db2c77
   m_configObjects: {}


### PR DESCRIPTION
## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
- 레디씬과 게임씬에 필요한 기능을 분리

## Key Changes
<!-- 핵심 변경 사항 -->
- SceneLoading 방식을 Runner.SceneLoad를 사용
- 최초 게임 실행 시 SceneInfo를 설정하는 방식으로 변경
- ReadyScene 스크립트 추가, ReadyScene 추가

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
- .gitignore에 FusionDemos 폴더 추가
- 테스트 용도로 플레이어 숫자 2명으로 변경
- BaseAnimController, Crew를 Creature로 수정
- ObjectManager::Despawn에서 Crew를 Creature로 수정

