### PR TITLE
feat: Random Spawn 로직 추가 & Name Tag 버그 수정

### DIFF
--- a/Client/Assets/Resources/Prefabs/Creatures/Stalker.prefab
+++ b/Client/Assets/Resources/Prefabs/Creatures/Stalker.prefab
@@ -1036,6 +1036,7 @@ GameObject:
   - component: {fileID: 2516994780171337258}
   - component: {fileID: 4476358356948161216}
   - component: {fileID: 9205723220890699314}
+  - component: {fileID: -3236823099726202573}
   m_Layer: 0
   m_Name: Stalker
   m_TagString: Untagged
@@ -1153,6 +1154,7 @@ MonoBehaviour:
   - {fileID: 2516994780171337258}
   - {fileID: 4476358356948161216}
   - {fileID: 9205723220890699314}
+  - {fileID: -3236823099726202573}
 --- !u!114 &8848567419615919483
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1256,6 +1258,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94ff61e00a954d2ca211bbcd85136341, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &-3236823099726202573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8694943018831287373}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b400222cb0cf8bb4f824f28e394d4024, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _PlayerName:
+    _length: 0
+    _data:
+      Data: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  _State: 0
 --- !u!1 &8694943018831287375
 GameObject:
   m_ObjectHideFlags: 0

--- a/Client/Assets/Resources/Prefabs/Etc/SpawnPoint.prefab
+++ b/Client/Assets/Resources/Prefabs/Etc/SpawnPoint.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5384606949959395280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9166364103254612225}
+  - component: {fileID: 2730589226635763812}
+  m_Layer: 0
+  m_Name: SpawnPoint
+  m_TagString: Respawn
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9166364103254612225
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5384606949959395280}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -7, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2730589226635763812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5384606949959395280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 300e3304b544343479288ebc188e8597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Client/Assets/Resources/Prefabs/Etc/SpawnPoint.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/Etc/SpawnPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1eabd857b3570234682731447dbf1179
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scenes/GameScene.unity
+++ b/Client/Assets/Scenes/GameScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 1.1216525, g: 0.8648306, b: 0.96941197, a: 1}
+  m_IndirectSpecularColor: {r: 1.1195, g: 0.86272377, b: 0.96699893, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -237,6 +237,10 @@ PrefabInstance:
     - target: {fileID: 623274300692448491, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965716298221596158, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
+      propertyPath: SortKey
+      value: 3892971456
       objectReference: {fileID: 0}
     - target: {fileID: 2796764676794190687, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: SortKey
@@ -1940,6 +1944,72 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 174728257}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &183616282
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.607
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 26.913
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &183616283 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 183616282}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &199092890
 GameObject:
   m_ObjectHideFlags: 0
@@ -2046,37 +2116,72 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &212435519
-GameObject:
+--- !u!1001 &213753320
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 212435520}
-  m_Layer: 0
-  m_Name: SpawnPoint
-  m_TagString: Respawn
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &212435520
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 212435519}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -7, y: 0.5, z: -5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 15.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &213753321 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 213753320}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &232036150
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2572,6 +2677,10 @@ PrefabInstance:
     - target: {fileID: 4434731665901641938, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5728729387097700069, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
+      propertyPath: SortKey
+      value: 493071600
       objectReference: {fileID: 0}
     - target: {fileID: 8460561394741268781, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
       propertyPath: SortKey
@@ -4249,6 +4358,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1656200275}
     m_Modifications:
+    - target: {fileID: -7457825579007306682, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
+      propertyPath: SortKey
+      value: 1676121499
+      objectReference: {fileID: 0}
     - target: {fileID: 2651083800596193779, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
       propertyPath: m_Name
       value: SmallRoom
@@ -5273,6 +5386,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: 307271828787182045, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
+      propertyPath: SortKey
+      value: 3759239198
+      objectReference: {fileID: 0}
     - target: {fileID: 2745531498441078155, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
       propertyPath: SortKey
       value: 345062350
@@ -5971,6 +6088,72 @@ ReflectionProbe:
   m_UseOcclusionCulling: 1
   m_Importance: 1
   m_CustomBakedTexture: {fileID: 0}
+--- !u!1001 &1009208745
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1009208746 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1009208745}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1013145989
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6191,6 +6374,44 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1076734226}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1106425475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1106425476}
+  m_Layer: 0
+  m_Name: '@SpawnPoints'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1106425476
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106425475}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1246314503}
+  - {fileID: 213753321}
+  - {fileID: 183616283}
+  - {fileID: 1837942676}
+  - {fileID: 1417823752}
+  - {fileID: 1009208746}
+  - {fileID: 1506266028}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1106544961
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7335,6 +7556,68 @@ ReflectionProbe:
   m_UseOcclusionCulling: 1
   m_Importance: 1
   m_CustomBakedTexture: {fileID: 0}
+--- !u!1001 &1246314502
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1246314503 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1246314502}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1247980437
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8076,6 +8359,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: -3566309621943815494, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
+      propertyPath: SortKey
+      value: 3363861744
+      objectReference: {fileID: 0}
     - target: {fileID: 1319853832897710942, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -8328,6 +8615,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4206683368507738, guid: 190104e9bd5f8014eaf9a7f5f6f7a173, type: 3}
   m_PrefabInstance: {fileID: 1417034955}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1417823751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 19.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1417823752 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1417823751}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1487999883
 PrefabInstance:
@@ -8714,6 +9067,72 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a63cddc2e958b834eb28525cceb11e61, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1506266027
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.036
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.998
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1506266028 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1506266027}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1528917505
 GameObject:
   m_ObjectHideFlags: 0
@@ -9724,6 +10143,72 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1831336963}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1837942675
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1106425476}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.829
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1837942676 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1837942675}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1839988417
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10300,6 +10785,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1656200275}
     m_Modifications:
+    - target: {fileID: -7191254219799594112, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
+      propertyPath: SortKey
+      value: 566905816
+      objectReference: {fileID: 0}
     - target: {fileID: 76067771806322262, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
       propertyPath: SortKey
       value: 1799045824
@@ -11080,6 +11569,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: -3792083174078081579, guid: e26d3f8bca6fbf943b5cd072cc024214, type: 3}
+      propertyPath: SortKey
+      value: 587371210
+      objectReference: {fileID: 0}
     - target: {fileID: 745738969842464459, guid: e26d3f8bca6fbf943b5cd072cc024214, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -11177,4 +11670,4 @@ SceneRoots:
   - {fileID: 1498853708}
   - {fileID: 1158283467}
   - {fileID: 1380135492}
-  - {fileID: 212435520}
+  - {fileID: 1106425476}

--- a/Client/Assets/Scenes/ReadyScene.unity
+++ b/Client/Assets/Scenes/ReadyScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 1.121193, g: 0.8641804, b: 0.9683758, a: 1}
+  m_IndirectSpecularColor: {r: 1.1195, g: 0.86272377, b: 0.96699893, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -214,6 +214,10 @@ PrefabInstance:
     - target: {fileID: 623274300692448491, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1965716298221596158, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
+      propertyPath: SortKey
+      value: 1177865762
       objectReference: {fileID: 0}
     - target: {fileID: 2796764676794190687, guid: 92e28f0336c771f4ca772e8a55afa4bb, type: 3}
       propertyPath: SortKey
@@ -1034,6 +1038,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4206683368507738, guid: 190104e9bd5f8014eaf9a7f5f6f7a173, type: 3}
   m_PrefabInstance: {fileID: 50717013}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &63111420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 21.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &63111421 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 63111420}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &64879364
 PrefabInstance:
@@ -2023,37 +2093,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &212435519
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 212435520}
-  m_Layer: 0
-  m_Name: SpawnPoint
-  m_TagString: Respawn
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &212435520
+--- !u!4 &212435520 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 2072522213592185224}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 212435519}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -7, y: 0.5, z: -5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &232036150
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2549,6 +2593,10 @@ PrefabInstance:
     - target: {fileID: 4434731665901641938, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5728729387097700069, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
+      propertyPath: SortKey
+      value: 2072933202
       objectReference: {fileID: 0}
     - target: {fileID: 8460561394741268781, guid: fea750ca11e6ba249b98f8ae77885de2, type: 3}
       propertyPath: SortKey
@@ -4226,6 +4274,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1656200275}
     m_Modifications:
+    - target: {fileID: -7457825579007306682, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
+      propertyPath: SortKey
+      value: 3255983101
+      objectReference: {fileID: 0}
     - target: {fileID: 2651083800596193779, guid: 005573c83d9425342a8ff7b0ae93db59, type: 3}
       propertyPath: m_Name
       value: SmallRoom
@@ -4490,6 +4542,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 685004492}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &703523074
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 15.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &703523075 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 703523074}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &709716650
 PrefabInstance:
@@ -4935,6 +5053,72 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 829649679}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &850516808
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.607
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 26.913
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &850516809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 850516808}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &852152034
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5250,6 +5434,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: 307271828787182045, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
+      propertyPath: SortKey
+      value: 1044133504
+      objectReference: {fileID: 0}
     - target: {fileID: 2745531498441078155, guid: ffd93bb9279fbce4b80fd6459ce27d91, type: 3}
       propertyPath: SortKey
       value: 1924923952
@@ -8053,6 +8241,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: -3566309621943815494, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
+      propertyPath: SortKey
+      value: 648756050
+      objectReference: {fileID: 0}
     - target: {fileID: 1319853832897710942, guid: 93c0923847dc6bf439c85281792d1128, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -8920,6 +9112,44 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4206683368507738, guid: 190104e9bd5f8014eaf9a7f5f6f7a173, type: 3}
   m_PrefabInstance: {fileID: 1563979461}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1564929373
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1564929374}
+  m_Layer: 0
+  m_Name: '@SpawnPoints'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1564929374
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1564929373}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 212435520}
+  - {fileID: 703523075}
+  - {fileID: 850516809}
+  - {fileID: 1792048281}
+  - {fileID: 1949238097}
+  - {fileID: 63111421}
+  - {fileID: 1986386842}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1583042595
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9588,6 +9818,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1786788653}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1792048280
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.829
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1792048281 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1792048280}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1807861100
 PrefabInstance:
@@ -10277,6 +10573,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1656200275}
     m_Modifications:
+    - target: {fileID: -7191254219799594112, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
+      propertyPath: SortKey
+      value: 2146767418
+      objectReference: {fileID: 0}
     - target: {fileID: 76067771806322262, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
       propertyPath: SortKey
       value: 3378907426
@@ -10334,6 +10634,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1845699543241681820, guid: 20ec278c740cf8f4fb4d39b8883cb8f1, type: 3}
   m_PrefabInstance: {fileID: 1920570956}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1949238096
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 19.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1949238097 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1949238096}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1956324887
 PrefabInstance:
@@ -10446,6 +10812,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1973360633}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1986386841
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.036
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 28.998
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+--- !u!4 &1986386842 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+  m_PrefabInstance: {fileID: 1986386841}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1994152232
 PrefabInstance:
@@ -11057,6 +11489,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1528917506}
     m_Modifications:
+    - target: {fileID: -3792083174078081579, guid: e26d3f8bca6fbf943b5cd072cc024214, type: 3}
+      propertyPath: SortKey
+      value: 2167232812
+      objectReference: {fileID: 0}
     - target: {fileID: 745738969842464459, guid: e26d3f8bca6fbf943b5cd072cc024214, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -11144,6 +11580,63 @@ MonoBehaviour:
   Components:
   - {fileID: 2123864769}
   _guid: 4f16456c-565b-4102-
+--- !u!1001 &2072522213592185224
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1564929374}
+    m_Modifications:
+    - target: {fileID: 5384606949959395280, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1eabd857b3570234682731447dbf1179, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -11154,4 +11647,4 @@ SceneRoots:
   - {fileID: 1498853708}
   - {fileID: 1158283467}
   - {fileID: 1380135492}
-  - {fileID: 212435520}
+  - {fileID: 1564929374}

--- a/Client/Assets/Scripts/Contents/Player/SpawnPoint.cs
+++ b/Client/Assets/Scripts/Contents/Player/SpawnPoint.cs
@@ -1,0 +1,7 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpawnPoint : MonoBehaviour
+{
+}

--- a/Client/Assets/Scripts/Contents/Player/SpawnPoint.cs.meta
+++ b/Client/Assets/Scripts/Contents/Player/SpawnPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 300e3304b544343479288ebc188e8597
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
+++ b/Client/Assets/Scripts/Managers/Contents/ObjectManager.cs
@@ -35,6 +35,8 @@ public class ObjectManager
 
         Crew crew = no.GetComponent<Crew>();
         crew.SetInfo(crewDataId);
+        Player player = no.GetComponent<Player>();
+        player.PlayerRef = Managers.NetworkMng.Runner.LocalPlayer;
 
         return no;
     }
@@ -47,6 +49,8 @@ public class ObjectManager
 
         Alien alien = no.GetComponent<Alien>();
         alien.SetInfo(alienDataId);
+        Player player = no.GetComponent<Player>();
+        player.PlayerRef = Managers.NetworkMng.Runner.LocalPlayer;
 
         return no;
     }

--- a/Client/Assets/Scripts/Managers/Core/NetworkManager.cs
+++ b/Client/Assets/Scripts/Managers/Core/NetworkManager.cs
@@ -153,6 +153,7 @@ public class NetworkManager : MonoBehaviour, INetworkRunnerCallbacks
 
             NetworkObject playerObject = Managers.ObjectMng.SpawnCrew(Define.CREW_CREWA_ID, position);
             runner.SetPlayerObject(runner.LocalPlayer, playerObject);
+            
             if (Runner.IsSharedModeMasterClient)
             {
                 NetworkObject prefab = Managers.ResourceMng.Load<NetworkObject>($"Prefabs/Etc/PlayerSystem");

--- a/Client/Assets/Scripts/Networks/LevelManager.cs
+++ b/Client/Assets/Scripts/Networks/LevelManager.cs
@@ -42,15 +42,20 @@ public class LevelManager : NetworkSceneManagerDefault
                 position = spawnPoint.transform.position;
             }
 
+            try
+            {
+                position = Managers.NetworkMng.PlayerSystem.SpawnPoints.Get(Managers.NetworkMng.Runner.LocalPlayer);
+            }
+            catch (Exception e)
+            {
+                Debug.Log(e);
+            }
+
             NetworkObject playerObject = Managers.ObjectMng.SpawnCrew(Define.CREW_CREWA_ID, position);
             Managers.NetworkMng.Runner.SetPlayerObject(Managers.NetworkMng.Runner.LocalPlayer, playerObject);
 
             if (Runner.IsSharedModeMasterClient)
             {
-                NetworkObject prefab = Managers.ResourceMng.Load<NetworkObject>($"Prefabs/Etc/PlayerSystem");
-                NetworkObject no = Managers.NetworkMng.Runner.Spawn(prefab, Vector3.zero);
-                Managers.NetworkMng.PlayerSystem = no.GetComponent<PlayerSystem>();
-
                 var players = Managers.NetworkMng.Runner.ActivePlayers.ToList();
                 int random = Random.Range(0, players.Count);
                 Player.RPC_ChangePlayerToAlien(Managers.NetworkMng.Runner, players[random], Define.ALIEN_STALKER_ID);

--- a/Client/Assets/Scripts/Networks/Player.cs
+++ b/Client/Assets/Scripts/Networks/Player.cs
@@ -78,8 +78,8 @@ public class Player : NetworkBehaviour
         {
             await Task.Delay(100);
         }
-        Managers.ObjectMng.Despawn(po);
         Vector3 spawnPosition = po.transform.position;
+        Managers.ObjectMng.Despawn(po);
         NetworkObject no = Managers.ObjectMng.SpawnAlien(alienDataId, spawnPosition);
         runner.SetPlayerObject(player, no);
     }

--- a/Client/Assets/Scripts/Networks/Player.cs
+++ b/Client/Assets/Scripts/Networks/Player.cs
@@ -11,7 +11,11 @@ public class Player : NetworkBehaviour
 {
     [Networked] public NetworkString<_32> PlayerName { get; set; }
 
+    [Networked]
+    public PlayerRef PlayerRef { get; set; }
     public Action OnPlayerNameUpdate { get; set; }
+
+    public Creature Creature { get; set; }
     [Networked]
     public Define.PlayerState State { get; set; } = Define.PlayerState.None;
 
@@ -36,11 +40,20 @@ public class Player : NetworkBehaviour
     {
         yield return new WaitUntil(() => isActiveAndEnabled);
 
-        Managers.UIMng.MakeWorldSpaceUI<UI_NameTag>(transform);
+        var creature = GetComponent<Creature>();
+        if (creature.CreatureType == Define.CreatureType.Crew)
+        {
+            var ui = Managers.UIMng.MakeWorldSpaceUI<UI_NameTag>(transform);
+
+            if (PlayerRef == Runner.LocalPlayer)
+            {
+                ui.gameObject.SetActive(false);
+            }
+        }
 
         yield return new WaitUntil(() => Object != null && Object.IsValid);
 
-        OnPlayerNameUpdate.Invoke();
+        OnPlayerNameUpdate?.Invoke();
     }
 
     public void GetReady()

--- a/Client/Assets/Scripts/Networks/PlayerSystem.cs
+++ b/Client/Assets/Scripts/Networks/PlayerSystem.cs
@@ -1,6 +1,7 @@
 using Fusion;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -9,6 +10,15 @@ public class PlayerSystem : NetworkBehaviour
     [Networked, OnChangedRender(nameof(OnReadyCountChanged))]
     public int ReadyCount { get; set; }
     public Action OnReadyCountUpdated { get; set; }
+
+    [Networked, Capacity(Define.PLAYER_COUNT)]
+    public NetworkDictionary<PlayerRef, Vector3> SpawnPoints { get; }
+
+    public override void Spawned()
+    {
+        DontDestroyOnLoad(gameObject);
+    }
+
     public void OnReadyCountChanged()
     {
         OnReadyCountUpdated?.Invoke();

--- a/Client/Assets/Scripts/UI/WorldSpace/UI_NameTag.cs
+++ b/Client/Assets/Scripts/UI/WorldSpace/UI_NameTag.cs
@@ -39,6 +39,9 @@ public class UI_NameTag : UI_Base
 
         Nickname = GetText((int)Texts.Nickname);
 
+        transform.localPosition = new Vector3(0, 2.0f, 0);
+        transform.localRotation = Quaternion.Euler(0, 0, 0);
+
         Player = transform.parent.GetComponent<Player>();
         Player.OnPlayerNameUpdate += () => Nickname.text = Player.PlayerName.Value;
 

--- a/Client/Assets/_Extra_Assets/Photon.meta
+++ b/Client/Assets/_Extra_Assets/Photon.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 34c8ceb866579e643a5d335c6a5c8f5d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Client/Assets/_Extra_Assets/Photon/FusionAddons.meta
+++ b/Client/Assets/_Extra_Assets/Photon/FusionAddons.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 217519d8b27648543b08010a1118ba19
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Client/ProjectSettings/EditorBuildSettings.asset
+++ b/Client/ProjectSettings/EditorBuildSettings.asset
@@ -14,10 +14,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: 9fc0d4010bbf28b4594072e72b8655ab
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/TestScene/TestSceneTemplate.unity
     guid: 4362e3aefe6b16b4aa2c685fb71f2d44
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/TestScene/DemoMapScene.unity
     guid: 609a849c20fe4c14eb20fe9692d284c2
   - enabled: 0


### PR DESCRIPTION
## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
- 초반 게임이 시작될 때, 어느 위치에 스폰되어야 하는지 결정하기 위해서

## Key Changes
<!-- 핵심 변경 사항 -->
- Game Scene과 Ready Scene에 스폰포인트 프리팹 추가
- 네임 태그 UI 버그 수정 & 내 자신의 네임 태그는 보이지 않게 수정
- 에일리언은 네임 태그가 뜨지 않게 처리

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
- SpawnPoint는 초반 스폰 장소
- Respawn 태그가 붙은 경우에는 다시 살아날 때 스폰 장소 혹은 기본 스폰 장소
