### PR TITLE
refactor: separate plan system from mapsystem

### DIFF
--- a/Client/Assets/Resources/Prefabs/Map/@MapSystem.prefab
+++ b/Client/Assets/Resources/Prefabs/Map/@MapSystem.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 14220058542274128}
   - component: {fileID: 3213453872573541556}
   - component: {fileID: 1501787418130949391}
+  - component: {fileID: 8575483182416784577}
   m_Layer: 0
   m_Name: '@MapSystem'
   m_TagString: Untagged
@@ -51,6 +52,7 @@ MonoBehaviour:
   NestedObjects: []
   NetworkedBehaviours:
   - {fileID: 1501787418130949391}
+  - {fileID: 8575483182416784577}
 --- !u!114 &1501787418130949391
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -73,4 +75,18 @@ MonoBehaviour:
     GlobalMinCount: 1
     GlobalMaxCount: 4
     MaxCountPerSector: 2
-  _BatteryCollectCount: 0
+--- !u!114 &8575483182416784577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6805510342841796365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c160b5c6947d1e34ea6fe249fb97cea6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _BatteryChargeCount: 0
+  _IsGeneratorRestored:
+    _value: 0

--- a/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/BatteryCharger.cs
+++ b/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/BatteryCharger.cs
@@ -29,7 +29,7 @@ public class BatteryCharger : BaseWorkStation
             return true;
         }
 
-        if (Managers.MapMng.MapSystem.IsBatteryChargeFinished)
+        if (Managers.MapMng.PlanSystem.IsBatteryChargeFinished)
         {
             creature.IngameUI.InteractInfoUI.Hide();
             creature.IngameUI.ErrorTextUI.Show("All batteries are charged already");
@@ -60,7 +60,7 @@ public class BatteryCharger : BaseWorkStation
     protected override void Rpc_WorkComplete()
     {
         CurrentWorkAmount = 0;
-        Managers.MapMng.MapSystem.BatteryChargeCount++;
+        Managers.MapMng.PlanSystem.BatteryChargeCount++;
     }
     protected override void PlayInteractAnimation()
     {

--- a/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/ElevatorKeypad.cs
+++ b/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/ElevatorKeypad.cs
@@ -26,7 +26,7 @@ public class ElevatorKeypad : BaseWorkStation
             return false;
         }
 
-        if (!Managers.MapMng.MapSystem.IsGeneratorRestored)
+        if (!Managers.MapMng.PlanSystem.IsGeneratorRestored)
         {
             creature.IngameUI.ErrorTextUI.Show("You cannot use this now");
         }

--- a/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/GeneratorController.cs
+++ b/Client/Assets/Scripts/Contents/Map/Interactable/WorkStation/GeneratorController.cs
@@ -19,14 +19,14 @@ public class GeneratorController : BaseWorkStation
         if (creature.CreatureType == Define.CreatureType.Alien)
             return false;
 
-        if (Managers.MapMng.MapSystem.IsGeneratorRestored)
+        if (Managers.MapMng.PlanSystem.IsGeneratorRestored)
         {
             creature.IngameUI.InteractInfoUI.Hide();
             creature.IngameUI.ErrorTextUI.Show("The generator has already been restored");
             return true;
         }
 
-        if (!Managers.MapMng.MapSystem.IsBatteryChargeFinished)
+        if (!Managers.MapMng.PlanSystem.IsBatteryChargeFinished)
         {
             creature.IngameUI.InteractInfoUI.Hide();
             creature.IngameUI.ErrorTextUI.Show("You cannot use this now");
@@ -52,7 +52,7 @@ public class GeneratorController : BaseWorkStation
     {
         if (IsCompleted) return;
         IsCompleted = true;
-        Managers.MapMng.MapSystem.IsGeneratorRestored = true;
+        Managers.MapMng.PlanSystem.IsGeneratorRestored = true;
     }
 
     protected override void PlayInteractAnimation()

--- a/Client/Assets/Scripts/Contents/Map/MapSystem.cs
+++ b/Client/Assets/Scripts/Contents/Map/MapSystem.cs
@@ -13,10 +13,6 @@ public class MapSystem : NetworkBehaviour
     [Header("Item Spawn")]
     [SerializeField] private int _totalItemCount;
     [SerializeField] private List<ItemSpawnData> _itemSpawnDatas;
-
-    [Networked, OnChangedRender(nameof(OnBatteryCharge))] public int BatteryChargeCount { get; set; }
-    public bool IsBatteryChargeFinished { get; private set; }
-    [Networked, OnChangedRender(nameof(OnGeneratorRestored))] public NetworkBool IsGeneratorRestored { get; set; }
     
     public void Init()
     {
@@ -134,24 +130,5 @@ public class MapSystem : NetworkBehaviour
             Debug.LogWarning($"{data.Prefab.name}: Could not select sector!");
             return false;
         }
-    }
-
-    private void OnBatteryCharge()
-    {
-        if (Managers.ObjectMng.MyCreature is Alien) return;
-
-        Managers.ObjectMng.MyCrew.CrewIngameUI.ObjectiveUI.UpdateBatteryCount(BatteryChargeCount);
-
-        if (BatteryChargeCount == Define.BATTERY_COLLECT_GOAL)
-        {
-            IsBatteryChargeFinished = true;
-        }
-    }
-
-    private void OnGeneratorRestored()
-    {
-        if (Managers.ObjectMng.MyCreature is Alien) return;
-
-        Managers.ObjectMng.MyCrew.CrewIngameUI.ObjectiveUI.OnGeneratorRestored();
     }
 }

--- a/Client/Assets/Scripts/Contents/Map/PlanSystem.cs
+++ b/Client/Assets/Scripts/Contents/Map/PlanSystem.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Fusion;
+
+public class PlanSystem : NetworkBehaviour
+{
+    [Networked, OnChangedRender(nameof(OnBatteryCharge))] public int BatteryChargeCount { get; set; }
+    public bool IsBatteryChargeFinished { get; private set; }
+    [Networked, OnChangedRender(nameof(OnGeneratorRestored))] public NetworkBool IsGeneratorRestored { get; set; }
+
+    public void Init()
+    {
+        Managers.MapMng.PlanSystem = this;
+    }
+    
+    private void OnBatteryCharge()
+    {
+        if (Managers.ObjectMng.MyCreature is Alien) return;
+
+        Managers.ObjectMng.MyCrew.CrewIngameUI.ObjectiveUI.UpdateBatteryCount(BatteryChargeCount);
+
+        if (BatteryChargeCount == Define.BATTERY_COLLECT_GOAL)
+        {
+            IsBatteryChargeFinished = true;
+        }
+    }
+
+    private void OnGeneratorRestored()
+    {
+        if (Managers.ObjectMng.MyCreature is Alien) return;
+
+        Managers.ObjectMng.MyCrew.CrewIngameUI.ObjectiveUI.OnGeneratorRestored();
+    }
+}

--- a/Client/Assets/Scripts/Contents/Map/PlanSystem.cs.meta
+++ b/Client/Assets/Scripts/Contents/Map/PlanSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c160b5c6947d1e34ea6fe249fb97cea6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Scripts/Managers/Contents/MapManager.cs
+++ b/Client/Assets/Scripts/Managers/Contents/MapManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class MapManager
 {
     public MapSystem MapSystem { get; set; }
+    public PlanSystem PlanSystem { get; set; }
 
     public void Init()
     {

--- a/Client/Assets/Scripts/Scenes/GameScene.cs
+++ b/Client/Assets/Scripts/Scenes/GameScene.cs
@@ -15,12 +15,16 @@ public class GameScene : BaseScene
     public override IEnumerator OnSceneLoaded()
     {
         MapSystem mapSystem = null;
-        while (mapSystem == null)
+        PlanSystem planSystem = null;
+        while (mapSystem == null || planSystem == null)
         {
             mapSystem = FindObjectOfType<MapSystem>();
+            planSystem = FindObjectOfType<PlanSystem>();
             yield return new WaitForSeconds(0.5f);
         }
         mapSystem.Init();
+        planSystem.Init();
+
 
         UI_Ingame ingameUI = Managers.ObjectMng.MyCreature is Crew ? Managers.UIMng.ShowSceneUI<UI_CrewIngame>() : Managers.UIMng.ShowSceneUI<UI_AlienIngame>();
         yield return new WaitUntil(() => ingameUI.Init());

--- a/Client/Assets/Scripts/UI/SubItem/UI_CrewObjective.cs
+++ b/Client/Assets/Scripts/UI/SubItem/UI_CrewObjective.cs
@@ -66,9 +66,9 @@ public class UI_CrewObjective : UI_Base
             _textLock = true;
             yield return _colorTweener.WaitForCompletion();
             yield return new WaitForSeconds(1f);
+            _objectiveText.fontStyle = FontStyles.Strikethrough;
 
             yield return _objectiveText.DOColor(Color.gray, 1f).WaitForCompletion();
-            _objectiveText.fontStyle = FontStyles.Strikethrough;
 
             yield return new WaitForSeconds(1f);
 


### PR DESCRIPTION
## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 업데이트
- [x] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
- MapSystem이 아이템 생성, 플랜 관리 역할을 둘 다 맡는 것이 적절하지 않다고 생각

## Key Changes
<!-- 핵심 변경 사항 -->
- PlanSystem을 만들어 게임 목표 관련 코드 이전
- MapManager가 MapSystem과 PlanSystem을 필드로 가짐

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
- MapSystem의 이름을 변경하지는 않음. 
- 현재는 아이템 생성만 하지만, 이후 섹터나 맵 자체에 관한 기능이 추가될 가능성이 있기 때문.  
- MapSystem이 맵의 모든 Sector를 저장한 딕셔너리를 가지는데, 이 딕셔너리가 아이템 생성에도 필요하고 추후 추가될 기능에도 필요할 수 있기에 클래스명 변경은 보류함. 
- 새로운 기능이 필요하다면 MapSystem에 해당 새 기능을 구현하고 아이템 생성 코드를 다시 분리할 계획.
