### PR TITLE
R키 자해 및 피격 스크린 업데이트 (#79)

### DIFF
--- a/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Custom Pass.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Custom Pass.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3314023010107842849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9091504092192553771}
+  - component: {fileID: 5956380388762015994}
+  - component: {fileID: 7051677923918251078}
+  m_Layer: 0
+  m_Name: Damage Screen Custom Pass
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9091504092192553771
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3314023010107842849}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5956380388762015994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3314023010107842849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26d6499a6bd256e47b859377446493a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsGlobal: 1
+  fadeRadius: 0
+  priority: 0
+  customPasses:
+  - rid: 2836041126369296384
+  injectionPoint: 2
+  m_TargetCamera: {fileID: 0}
+  useTargetCamera: 0
+  references:
+    version: 2
+    RefIds:
+    - rid: 2836041126369296384
+      type: {class: FullScreenCustomPass, ns: UnityEngine.Rendering.HighDefinition, asm: Unity.RenderPipelines.HighDefinition.Runtime}
+      data:
+        m_Name: Custom Pass
+        enabled: 1
+        targetColorBuffer: 0
+        targetDepthBuffer: 0
+        clearFlags: 0
+        passFoldout: 0
+        m_Version: 0
+        fullscreenPassMaterial: {fileID: 2100000, guid: 634e21b62369337459efb5d402a11298, type: 2}
+        materialPassIndex: 0
+        materialPassName: Custom Pass 0
+        fetchColorBuffer: 0
+--- !u!114 &7051677923918251078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3314023010107842849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f2b2c6cbec70e5b4a84f678f229ac8a5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  screenDamageMat: {fileID: 2100000, guid: 634e21b62369337459efb5d402a11298, type: 2}

--- a/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Custom Pass.prefab.meta
+++ b/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Custom Pass.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 57d11c90b75f9144e84ad6adb390421f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Shader Graph.shadergraph
+++ b/Client/Assets/Resources/Prefabs/UI/Screen/Damage Screen Shader Graph.shadergraph
@@ -2171,7 +2171,7 @@
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 0.0,
+    "m_Value": 1.0,
     "m_FloatType": 0,
     "m_RangeValues": {
         "x": 0.0,

--- a/Client/Assets/Resources/Prefabs/UI/Screen/DamageScreenMaterial.mat
+++ b/Client/Assets/Resources/Prefabs/UI/Screen/DamageScreenMaterial.mat
@@ -37,8 +37,10 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Ints: []
     m_Floats:
+    - _Blur: 0
+    - _Vignette_blur: 2.5
     - _Vignette_darkening: 1
-    - _Vignette_radius: 0.07
+    - _Vignette_radius: -1
     - _Vignette_softness: 1
     m_Colors:
     - _Tint: {r: 0.8773585, g: 0.0198647, b: 0.0198647, a: 0}

--- a/Client/Assets/Scenes/GameScene.unity
+++ b/Client/Assets/Scenes/GameScene.unity
@@ -1104,6 +1104,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9166364103254612225, guid: 1eabd857b3570234682731447dbf1179, type: 3}
   m_PrefabInstance: {fileID: 1837942675}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2144393721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3314023010107842849, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_Name
+      value: Damage Screen Custom Pass
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1117,3 +1174,4 @@ SceneRoots:
   - {fileID: 750101080}
   - {fileID: 26132785}
   - {fileID: 279414586}
+  - {fileID: 2144393721}

--- a/Client/Assets/Scenes/TestScene/Map_JSJ.unity
+++ b/Client/Assets/Scenes/TestScene/Map_JSJ.unity
@@ -24,7 +24,7 @@ RenderSettings:
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
-  m_AmbientMode: 0
+  m_AmbientMode: 4
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: 0.5
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.7476371, g: 0.5764833, b: 0.64621836, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -6332,75 +6332,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4275698116916540, guid: 68615fcf1489c0847af4caef5f07e486, type: 3}
   m_PrefabInstance: {fileID: 1626266841}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1627989253
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1627989255}
-  - component: {fileID: 1627989254}
-  m_Layer: 0
-  m_Name: Damage Screen Custom Pass
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1627989254
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1627989253}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 26d6499a6bd256e47b859377446493a1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IsGlobal: 1
-  fadeRadius: 0
-  priority: 0
-  customPasses:
-  - rid: 2836041078839705600
-  injectionPoint: 2
-  m_TargetCamera: {fileID: 0}
-  useTargetCamera: 0
-  references:
-    version: 2
-    RefIds:
-    - rid: 2836041078839705600
-      type: {class: FullScreenCustomPass, ns: UnityEngine.Rendering.HighDefinition, asm: Unity.RenderPipelines.HighDefinition.Runtime}
-      data:
-        m_Name: Damage Screen Custom Pass
-        enabled: 1
-        targetColorBuffer: 0
-        targetDepthBuffer: 0
-        clearFlags: 0
-        passFoldout: 0
-        m_Version: 0
-        fullscreenPassMaterial: {fileID: 2100000, guid: 634e21b62369337459efb5d402a11298, type: 2}
-        materialPassIndex: 0
-        materialPassName: Custom Pass 0
-        fetchColorBuffer: 0
---- !u!4 &1627989255
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1627989253}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1629159834
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8674,6 +8605,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6fdb3aaf5497e1547918aafa36904b69, type: 3}
+--- !u!1001 &5635923846375303012
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3314023010107842849, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_Name
+      value: Damage Screen Custom Pass
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9091504092192553771, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 57d11c90b75f9144e84ad6adb390421f, type: 3}
 --- !u!1001 &8066887517864003942
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8755,4 +8743,4 @@ SceneRoots:
   - {fileID: 780245792}
   - {fileID: 8066887517864003942}
   - {fileID: 4224064891719687739}
-  - {fileID: 1627989255}
+  - {fileID: 5635923846375303012}

--- a/Client/Assets/Scripts/Controllers/Crew.cs
+++ b/Client/Assets/Scripts/Controllers/Crew.cs
@@ -81,6 +81,9 @@ public class Crew : Creature
             return;
         }
 
+        if (Input.GetKeyDown(KeyCode.R))
+            Rpc_OnDamaged(1);
+
         if (Input.GetKeyDown(KeyCode.F))
             if (CheckInteractable(true))
                 return;
@@ -253,7 +256,17 @@ public class Crew : Creature
         if (CrewStat.Hp <= 0)
         {
             OnDead();
+            UI_DamageScreen.DamageEffects.ScreenDamageEffect(1f);
             return;
+        }
+
+        if (CrewStat.Hp == 1)
+        {
+            UI_DamageScreen.DamageEffects.ScreenDamageEffect(0.5f);
+        }
+        else
+        {
+            UI_DamageScreen.DamageEffects.ScreenDamageEffect(0.3f);
         }
 
         CrewStat.OnStaminaChanged(Define.DAMAGED_RECOVER_STAMINA);

--- a/Client/Assets/Scripts/UI/SubItem/UI_DamageScreen.cs
+++ b/Client/Assets/Scripts/UI/SubItem/UI_DamageScreen.cs
@@ -1,0 +1,74 @@
+using Fusion;
+using Fusion.Addons.SimpleKCC;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+//using Cinemachine;
+
+public class UI_DamageScreen : UI_Base
+{
+    public Material screenDamageMat;
+    //public CinemachineImpulseSource impulseSource;
+    private Coroutine screenDamageTask;
+
+    private static UI_DamageScreen instance;
+
+    private float speed = 1.5f;
+
+    public override bool Init()
+    {
+        if (base.Init() == false)
+            return false;
+
+        instance = this;
+        screenDamageMat.SetFloat("_Vignette_radius", 1f);
+        return true;
+    }
+
+    private void ScreenDamageEffect(float intensity)
+    {
+        if (screenDamageTask != null)
+        {
+            StopCoroutine(screenDamageTask);
+        }
+        screenDamageTask = StartCoroutine(screenDamage(intensity));
+    }
+
+    private IEnumerator screenDamage(float intensity)
+    {
+        // Camera shake
+        //Vector3 velocity = new Vector3(0, -0.5f, -1);
+        //velocity.Normalize();
+        //impulseSource.GenerateImpulse(velocity * intensity * 0.4f);
+
+        // Screen effect
+        float targetRadius = Remap(intensity, 0, 1, 1.2f, -1f);
+        float curRadius = 1; // No damage
+        for (float t = 0; curRadius != targetRadius; t += Time.deltaTime * speed)
+        {
+            curRadius = Mathf.Lerp(1, targetRadius, t);
+            screenDamageMat.SetFloat("_Vignette_radius", curRadius);
+            yield return null;
+        }
+
+        if (intensity < 1)
+        {
+            for (float t = 0; curRadius < 1; t += Time.deltaTime * speed)
+            {
+                curRadius = Mathf.Lerp(targetRadius, 1, t);
+                screenDamageMat.SetFloat("_Vignette_radius", curRadius);
+                yield return null;
+            }
+        }
+    }
+
+    private float Remap(float value, float fromMin, float fromMax, float toMin, float toMax)
+    {
+        return Mathf.Lerp(toMin, toMax, Mathf.InverseLerp(fromMin, fromMax, value));
+    }
+
+    public static class DamageEffects
+    {
+        public static void ScreenDamageEffect(float intensity) => instance.ScreenDamageEffect(intensity);
+    }
+}

--- a/Client/Assets/Scripts/UI/SubItem/UI_DamageScreen.cs.meta
+++ b/Client/Assets/Scripts/UI/SubItem/UI_DamageScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2b2c6cbec70e5b4a84f678f229ac8a5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Crew가 R키를 눌러서 자해하면 피격 스크린을 확인할 수 있다.

## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
-피격 스크린

## Key Changes
<!-- 핵심 변경 사항 -->
-Crew가 R키를 누르면 자해하고, 피격 스크린을 확인할 수 있다.

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
-3번 자해하면 죽는데, 죽어도 UI가 사라지지 않고 캐릭터가 이동할 수 있는 문제점이 있다.
