### PR TITLE
feat: Alien&Crew 종료ui 수정 및 lobbyscene으로 돌아가는 버튼 기능 수정

### DIFF
--- a/Client/Assets/Resources/Animators/Alien_Defeat.controller
+++ b/Client/Assets/Resources/Animators/Alien_Defeat.controller
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-5431739795816923190
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: IdleLookAround
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 9454a4ef888bc584f92d32e8a41ad37c, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-3722685000878890290
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -5431739795816923190}
+    m_Position: {x: 520, y: 110, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -5431739795816923190}
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Alien_Defeat
+  serializedVersion: 5
+  m_AnimatorParameters: []
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3722685000878890290}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}

--- a/Client/Assets/Resources/Animators/Alien_Defeat.controller.meta
+++ b/Client/Assets/Resources/Animators/Alien_Defeat.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f8070a19f4e5b14f86b894b58d8a92a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienDefeat.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienDefeat.prefab
@@ -351,6 +351,140 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1440473893695836699
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6358368042781042649}
+  - component: {fileID: 184876611195485199}
+  - component: {fileID: 5920847132809961643}
+  m_Layer: 5
+  m_Name: Text3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6358368042781042649
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1440473893695836699}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2819248160265837892}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -600}
+  m_SizeDelta: {x: 1400, y: 200}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &184876611195485199
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1440473893695836699}
+  m_CullTransparentMesh: 1
+--- !u!114 &5920847132809961643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1440473893695836699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: All the crew hasn't left the room yet.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 537eb1eef138da7489d2d0c861629654, type: 2}
+  m_sharedMaterial: {fileID: -2009162042594335899, guid: 537eb1eef138da7489d2d0c861629654, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1871490033789674605
 GameObject:
   m_ObjectHideFlags: 0
@@ -776,6 +910,7 @@ RectTransform:
   - {fileID: 7680725331082701641}
   - {fileID: 393589269584403197}
   - {fileID: 8959203935548711403}
+  - {fileID: 6358368042781042649}
   - {fileID: 4243992266532714100}
   - {fileID: 7781879211728131189}
   - {fileID: 8091886788036622666}
@@ -2832,7 +2967,7 @@ Transform:
   m_GameObject: {fileID: 8091886788036977962}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.96592593, z: 0, w: -0.25881898}
-  m_LocalPosition: {x: 400, y: -400, z: 300}
+  m_LocalPosition: {x: 450, y: -400, z: 300}
   m_LocalScale: {x: 200, y: 200, z: 200}
   m_ConstrainProportionsScale: 1
   m_Children:
@@ -2850,7 +2985,7 @@ Animator:
   m_GameObject: {fileID: 8091886788036977962}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: 07f33cee22a1b194e9acf9165c916191, type: 3}
-  m_Controller: {fileID: 9100000, guid: 629af58db998c874a98988389a539b82, type: 2}
+  m_Controller: {fileID: 9100000, guid: 0f8070a19f4e5b14f86b894b58d8a92a, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0

--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienWin.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienWin.prefab
@@ -389,6 +389,140 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2820291064915336785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5079554486276921052}
+  - component: {fileID: 4116515408610415511}
+  - component: {fileID: 428870232354402464}
+  m_Layer: 5
+  m_Name: Text3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5079554486276921052
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2820291064915336785}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2819248160265837892}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -600}
+  m_SizeDelta: {x: 1400, y: 200}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4116515408610415511
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2820291064915336785}
+  m_CullTransparentMesh: 1
+--- !u!114 &428870232354402464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2820291064915336785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: All the crew hasn't left the room yet.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 537eb1eef138da7489d2d0c861629654, type: 2}
+  m_sharedMaterial: {fileID: -2009162042594335899, guid: 537eb1eef138da7489d2d0c861629654, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &3684441088453196049
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,6 +693,7 @@ RectTransform:
   - {fileID: 4495453586987430459}
   - {fileID: 393589269584403197}
   - {fileID: 8959203935548711403}
+  - {fileID: 5079554486276921052}
   - {fileID: 4243992266532714100}
   - {fileID: 7781879211728131189}
   - {fileID: 8091886788036622666}
@@ -652,7 +787,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5535641532313121958}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 0.03
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_CrewWin.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_CrewWin.prefab
@@ -3766,7 +3766,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5535641532313121958}
   m_Enabled: 1
-  m_Alpha: 0
+  m_Alpha: 0.78
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/Client/Assets/Scripts/Systems/GameEndSystem.cs
+++ b/Client/Assets/Scripts/Systems/GameEndSystem.cs
@@ -51,7 +51,8 @@ public class GameEndSystem : NetworkBehaviour
             else
             {
                 Managers.UIMng.ShowPopupUI<UI_AlienDefeat>();
-                alien.Rpc_OnEndGame();
+                alien.OnEndGame();
+                //alien.Rpc_OnEndGame();
             }
         }
     }

--- a/Client/Assets/Scripts/UI/Popup/UI_AlienDefeat.cs
+++ b/Client/Assets/Scripts/UI/Popup/UI_AlienDefeat.cs
@@ -1,3 +1,4 @@
+using DG.Tweening;
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
@@ -15,12 +16,14 @@ public class UI_AlienDefeat : UI_Popup
     enum Texts
     {
         Text1,
-        Text2
+        Text2,
+        Text3
     }
 
     private CanvasGroup CanvasGroup;
     private Coroutine FadeCor;
     private float accumTime = 0f;
+    private bool isAnimating = false;
 
     public override bool Init()
     {
@@ -31,6 +34,7 @@ public class UI_AlienDefeat : UI_Popup
         Bind<TMP_Text>(typeof(Texts));
 
         GetButton((int)Buttons.Quit).onClick.AddListener(ExitGame);
+        GetText(Texts.Text3).alpha = 0f;
 
         CanvasGroup = GetComponent<CanvasGroup>();
         StartFadeIn();
@@ -62,6 +66,24 @@ public class UI_AlienDefeat : UI_Popup
 
     public void ExitGame()
     {
-        Managers.GameMng.GameEndSystem.Exit();
+        if (Managers.NetworkMng.NumPlayers <= 1)
+        {
+            Managers.GameMng.GameEndSystem.Exit();
+        }
+        else
+        {
+            if (isAnimating)
+                return;
+
+            Sequence sequence = DOTween.Sequence();
+
+            sequence.Append(GetText(Texts.Text3).DOFade(1f, 1.5f).SetEase(Ease.OutQuad));
+            sequence.AppendInterval(0.5f);
+            sequence.Append(GetText(Texts.Text3).DOFade(0f, 1.5f).SetEase(Ease.OutQuad));
+            sequence.OnComplete(() => isAnimating = false);
+            sequence.Play();
+
+            isAnimating = true;
+        }
     }
 }

--- a/Client/Assets/Scripts/UI/Popup/UI_AlienWin.cs
+++ b/Client/Assets/Scripts/UI/Popup/UI_AlienWin.cs
@@ -1,3 +1,4 @@
+using DG.Tweening;
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
@@ -15,12 +16,14 @@ public class UI_AlienWin : UI_Popup
     enum Texts
     {
         Text1,
-        Text2
+        Text2,
+        Text3
     }
 
     private CanvasGroup CanvasGroup;
     private Coroutine FadeCor;
     private float accumTime = 0f;
+    private bool isAnimating = false;
 
     public override bool Init()
     {
@@ -31,6 +34,7 @@ public class UI_AlienWin : UI_Popup
         Bind<TMP_Text>(typeof(Texts));
 
         GetButton((int)Buttons.Quit).onClick.AddListener(ExitGame);
+        GetText(Texts.Text3).alpha = 0f;
 
         CanvasGroup = GetComponent<CanvasGroup>();
         StartFadeIn();
@@ -62,6 +66,24 @@ public class UI_AlienWin : UI_Popup
 
     public void ExitGame()
     {
-        Managers.GameMng.GameEndSystem.Exit();
+        if (Managers.NetworkMng.NumPlayers <= 1)
+        {
+            Managers.GameMng.GameEndSystem.Exit();
+        }
+        else
+        {
+            if (isAnimating)
+                return;
+
+            Sequence sequence = DOTween.Sequence();
+
+            sequence.Append(GetText(Texts.Text3).DOFade(1f, 1.5f).SetEase(Ease.OutQuad));
+            sequence.AppendInterval(0.5f);
+            sequence.Append(GetText(Texts.Text3).DOFade(0f, 1.5f).SetEase(Ease.OutQuad));
+            sequence.OnComplete(() => isAnimating = false);
+            sequence.Play();
+
+            isAnimating = true;
+        }
     }
 }


### PR DESCRIPTION
Alien&Crew 종료ui 수정 및 lobbyscene으로 돌아가는 버튼 기능 수정

## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
- Alien이 게임에서 졌을 때도 3D오브젝트가 보이도록 수정이 필요했음
- Room을 만든 alien 클라이언트가 다른 클라이언트보다 먼저 방을 나가게 되면 다른 클라이언트는 방에 갇히는 오류가 발생하여 이를 방지하기 위해 crew 클라이언트가 나가기 전까지 alien 클라이언트가 로비로 나가지 못하도록 막음

## Key Changes
<!-- 핵심 변경 사항 -->
- Alien의 게임종료 UI 두 개에 대한 코드를 부분적으로 수정
- GameEndSystem에서 alien이 defeat일 경우에 실행되는 코드 부분 수정

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
-
