### PR TITLE
bugfix: 텍스쳐 퀄리티 설정 & 엔딩 UI scalable 설정

### DIFF
--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienDefeat.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienDefeat.prefab
@@ -956,11 +956,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96

--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienWin.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_AlienWin.prefab
@@ -739,11 +739,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96

--- a/Client/Assets/Resources/Prefabs/UI/Popup/UI_CrewWin.prefab
+++ b/Client/Assets/Resources/Prefabs/UI/Popup/UI_CrewWin.prefab
@@ -3718,11 +3718,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96

--- a/Client/Assets/Scripts/Systems/SettingSystem.cs
+++ b/Client/Assets/Scripts/Systems/SettingSystem.cs
@@ -18,7 +18,7 @@ public class SettingSystem : MonoBehaviour
         set
         {
             PlayerPrefs.SetInt("Textures", value);
-            QualitySettings.SetQualityLevel(value);
+            SetQuality(value);
             _quality = value;
         }
     }
@@ -33,6 +33,11 @@ public class SettingSystem : MonoBehaviour
         Height = PlayerPrefs.GetInt("ScreenHeight", 1080);
         Quality = PlayerPrefs.GetInt("Textures", 1);
         VSycn = PlayerPrefs.GetInt("VSycn", 0);
+    }
+
+    private void SetQuality(int index)
+    {
+        QualitySettings.globalTextureMipmapLimit = 3 - index;
     }
 
     public void SetResolution(int width, int height)

--- a/Client/Assets/Scripts/Utils/Define.cs
+++ b/Client/Assets/Scripts/Utils/Define.cs
@@ -190,7 +190,7 @@ public static class Define
 
     #region Value
 
-    public const int PLAYER_COUNT = 3;
+    public const int PLAYER_COUNT = 2;
     public const int MAX_ITEM_NUM = 4;
     public const int MAX_SKILL_NUM = 4;
 


### PR DESCRIPTION
## PR 유형
<!-- 해당하는 유형에 "x"를 사용하여 대괄호 안에 표시 -->
- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 업데이트
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 기타 사항: *[지우고 직접 입력]*

## Motivation
<!-- 이 기능이 왜 필요한지 -->
- Quality Setting에 의미 부여
- 화면 해상도가 달라질 때, 엔딩 UI가 자리에서 벗어남

## Key Changes
<!-- 핵심 변경 사항 -->
- Quality를 변경하면 Mipmap 개수가 줄어들어 로드해야 하는 텍스쳐 메모리가 감소하도록 변경
- UI 프리팹에 Scalable 속성 설정

## To Reviewers
<!-- 주의할 점, 코드의 어느 부분을 보면 좋을지 -->
-
